### PR TITLE
Fix/jaeho/multi tx error handle

### DIFF
--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -73,14 +73,22 @@ export default class Connect {
 
   public sendTransaction = async (txInput: TransactionInput) => {
     const res = await this.ainJs.sendTransaction(txInput);
-    if (res.result && res.result.code) {
-      /* res: { result: { code: 'ERROR_CODE', message: 'ERROR_MESSAGE' } } */
-      throw Error(`[code:${res.result.code}]: ${res.result.message}`);
-    } else {
-      /* res: { result: any, tx_hash: 'TX_HASH' } */
-      // TODO: transfer TX 같은 경우, balance 부족으로 실패해도 tx hash가 생성된다.
-      return res;
+    if (res.result) {
+      if (res.result.code) {
+        /* res: { result: { code: 'ERROR_CODE', message: 'ERROR_MESSAGE' } } */
+        throw Error(`[code:${res.result.code}]: ${res.result.message}`);
+      } else if (res.result.result_list) {
+        Object.values(res.result.result_list).forEach((val: any) => {
+          if (val.code) {
+            /* res: { result: { result_list: { 0: { ... } } } } */
+            throw Error(`[code:${val.code}]: ${val.message}`);
+          }
+        });
+      }
     }
+    /* res: { result: any, tx_hash: 'TX_HASH' } */
+    // TODO: transfer TX 같은 경우, balance 부족으로 실패해도 tx hash가 생성된다.
+    return res;
   }
 
   public addEventListener = (

--- a/src/models/worker.ts
+++ b/src/models/worker.ts
@@ -111,7 +111,7 @@ export default class Worker {
     requestId: string,
     requestAddress: string,
     value: Types.SendResponseValue,
-  ) => {
+  ): Promise<any> => {
     const timestamp = Date.now();
     const txInput: TransactionInput = {
       operation: {
@@ -136,7 +136,8 @@ export default class Worker {
       },
       address: this.connect.getAddress(),
     };
-    await this.connect.sendTransaction(txInput);
+    const res = await this.connect.sendTransaction(txInput);
+    return res;
   }
 
   public getRequestQueue = async (

--- a/src/models/worker.ts
+++ b/src/models/worker.ts
@@ -111,7 +111,7 @@ export default class Worker {
     requestId: string,
     requestAddress: string,
     value: Types.SendResponseValue,
-  ): Promise<any> => {
+  ) => {
     const timestamp = Date.now();
     const txInput: TransactionInput = {
       operation: {

--- a/src/models/worker.ts
+++ b/src/models/worker.ts
@@ -136,8 +136,7 @@ export default class Worker {
       },
       address: this.connect.getAddress(),
     };
-    const res = await this.connect.sendTransaction(txInput);
-    return res;
+    await this.connect.sendTransaction(txInput);
   }
 
   public getRequestQueue = async (


### PR DESCRIPTION
worker.sendResponse 함수에서 multiTx 를 보낼 때 Tx 가 실패해도 별도의 에러 처리를 하지 않습니다.

connect.sendTransaction 에서 에러 핸들링 하는 코드를 추가했습니다. 
 
